### PR TITLE
Errore di dipendenza mancante (audioop)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 jupyterlab
 numpy
 scipy
+audioop-lts
 pydub
 matplotlib
 ipywebrtc


### PR DESCRIPTION
Errore di import quando viene eseguito il blocco: import settimanamatematica
Pydub lancia l'errore di dipendenza mancante quando prova a importare audioop. Sfortunatamente, come
da [questo issue](https://github.com/jiaaro/pydub/issues/725) tale libreria è stata deprecata nelle
versioni recenti. Aggiungendo audioop-lts al requirements.txt risolve il problema.